### PR TITLE
authorize arrow keys navigation in inputs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ class DisableScroll {
       disableWheel: true,
       disableScroll: true,
       disableKeys: true,
-      keyboardKeys: [32, 33, 34, 35, 36, 37, 38, 39, 40]
+      keyboardKeys: [32, 33, 34, 35, 36, 37, 38, 39, 40],
+      authorizedInInputs: [32, 37, 38, 39, 40]
       // space: 32, page up: 33, page down: 34, end: 35, home: 36
       // left: 37, up: 38, right: 39, down: 40
     };
@@ -81,11 +82,12 @@ class DisableScroll {
   };
 
   handleKeydown = (e) => {
-    let keys = [...this.options.keyboardKeys];
+    let keys;
+    
 
     /* istanbul ignore else */
     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
-      keys = keys.slice(1);
+      keys = this.options.authorizedInInputs;
     }
 
     /* istanbul ignore else */

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class DisableScroll {
   };
 
   handleKeydown = (e) => {
-    let keys = [...this.options.keyboardKeys];
+    let keys = this.options.keyboardKeys;
 
     /* istanbul ignore else */
     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {

--- a/src/index.js
+++ b/src/index.js
@@ -82,8 +82,7 @@ class DisableScroll {
   };
 
   handleKeydown = (e) => {
-    let keys;
-    
+    let keys = [...this.options.keyboardKeys];
 
     /* istanbul ignore else */
     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {


### PR DESCRIPTION
I added arrow keys in addition to space to be allowed in inputs (it's often used to navigate in the text)
Also, it’s better not to rely on slice since keyboardKeys can be modified in options.