### PR TITLE
Fix authorizedInInputs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class DisableScroll {
 
     /* istanbul ignore else */
     if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) {
-      keys = this.options.authorizedInInputs;
+      keys = keys.filter(key => !this.options.authorizedInInputs.includes(key));
     }
 
     /* istanbul ignore else */

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,6 +7,10 @@ describe('disable-scroll', () => {
   const wheelListener = jest.spyOn(disableScroll, 'handleWheel');
   const keyboardListener = jest.spyOn(disableScroll, 'handleKeydown');
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should have initialized', () => {
     expect(disableScroll.element).toBe(document.scrollingElement);
   });
@@ -29,8 +33,34 @@ describe('disable-scroll', () => {
     document.dispatchEvent(new Event('wheel'));
     document.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 32 }));
 
-    expect(scrollListener).toHaveBeenCalledTimes(1);
-    expect(wheelListener).toHaveBeenCalledTimes(1);
+    expect(scrollListener).toHaveBeenCalledTimes(0);
+    expect(wheelListener).toHaveBeenCalledTimes(0);
+    expect(keyboardListener).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not prevent space in input', () => {
+    disableScroll.on();
+
+    const input = document.createElement('input');
+    input.setAttribute('type', 'text');
+    input.setAttribute('name', 'test-input');
+    document.body.appendChild(input);
+    const dispatched = input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, keyCode: 32 }));
+
     expect(keyboardListener).toHaveBeenCalledTimes(1);
+    expect(dispatched).toEqual(true);
+  });
+
+  it('should prevent page down in input', () => {
+    disableScroll.on();
+
+    const input = document.createElement('input');
+    input.setAttribute('type', 'text');
+    input.setAttribute('name', 'test-input');
+    document.body.appendChild(input);
+    const dispatched = input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, keyCode: 34 }));
+
+    expect(keyboardListener).toHaveBeenCalledTimes(1);
+    expect(dispatched).toEqual(false);
   });
 });


### PR DESCRIPTION
## Expected Behavior
Given you have disabled scrolling with the default options
When you are focused on a text input
And you hit the spacebar
Then your input value should be updated to contain a space

## Current Behavior
The input value is not updated, and change/keypress events are not fired.

## Changes Made
* Add tests to demonstrate the bug
* Change the logic so that when the target is an input, `authorizedInInputs` are removed from keys that are blocked